### PR TITLE
Fixed incorrect section toggles

### DIFF
--- a/src/Osu.Music.UI/Resources/Converters/SelectedPageToToggleCheckCovnerter.cs
+++ b/src/Osu.Music.UI/Resources/Converters/SelectedPageToToggleCheckCovnerter.cs
@@ -1,0 +1,28 @@
+﻿using Prism.Mvvm;
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Osu.Music.UI.Resources.Converters
+{
+    public class SelectedPageToToggleCheckCovnerter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return false;
+
+            if (!(value is BindableBase))
+                throw new ArgumentException("Input argument must be of type BindableBase");
+
+            var type = value.GetType().Name;
+            var name = parameter as string;
+            return type == name;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Osu.Music.UI/Resources/Dictionaries/Buttons.xaml
+++ b/src/Osu.Music.UI/Resources/Dictionaries/Buttons.xaml
@@ -272,15 +272,14 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">
-                    <Border x:Name="Bd" CornerRadius="0" Background="{TemplateBinding Background}" BorderBrush="Transparent" BorderThickness="0 0 0 0" Padding="5 0 0 0">
+                    <StackPanel Orientation="Horizontal" Background="{TemplateBinding Background}">
+                        <Border x:Name="Bd" Width="5" BorderThickness="0 0 5 0" CornerRadius="0 5 5 0"/>
                         <ContentPresenter x:Name="contentPresenter" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                    </Border>
+                    </StackPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
                             <Setter Property="Foreground" Value="{DynamicResource SolidColorBrushMain}"/>
                             <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource SolidColorBrushMain}"/>
-                            <Setter TargetName="Bd" Property="BorderThickness" Value="5 0 0 0"/>
-                            <Setter TargetName="Bd" Property="Padding" Value="0 0 0 0"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/Osu.Music.UI/Resources/Dictionaries/Converters.xaml
+++ b/src/Osu.Music.UI/Resources/Dictionaries/Converters.xaml
@@ -17,4 +17,5 @@
     <convert:PackIconKindToStringConverter x:Key="PackIconKindToStringConverter"/>
     <convert:BrushStringConverter x:Key="BrushStringConverter"/>
     <convert:PlayerObjectToStringConverter x:Key="PlayerObjectToStringConverter"/>
+    <convert:SelectedPageToToggleCheckCovnerter x:Key="SelectedPageToToggleCheckCovnerter"/>
 </ResourceDictionary>

--- a/src/Osu.Music.UI/Views/MainView.xaml
+++ b/src/Osu.Music.UI/Views/MainView.xaml
@@ -55,9 +55,9 @@
             <Rectangle Fill="{DynamicResource SolidColorBrushMain}" Opacity="0.2" Grid.RowSpan="2"/>
 
             <StackPanel Orientation="Vertical" Margin="0 50 0 0">
-                <ToggleButton Style="{DynamicResource SidebarButtonAllSongs}" IsChecked="True" Command="{Binding OpenPageCommand}" CommandParameter="Songs"/>
+                <ToggleButton Style="{DynamicResource SidebarButtonAllSongs}" IsChecked="{Binding SelectedPage, Converter={StaticResource SelectedPageToToggleCheckCovnerter}, ConverterParameter=SongsViewModel, Mode=OneWay}" Command="{Binding OpenPageCommand}" CommandParameter="Songs"/>
+                <ToggleButton Style="{DynamicResource SidebarButtonPlaylists}" IsChecked="{Binding SelectedPage, Converter={StaticResource SelectedPageToToggleCheckCovnerter}, ConverterParameter=PlaylistsViewModel, Mode=OneWay}" Command="{Binding OpenPageCommand}" CommandParameter="Playlists"/>
                 <ToggleButton Style="{DynamicResource SidebarButtonCollection}" IsEnabled="False"/>
-                <ToggleButton Style="{DynamicResource SidebarButtonPlaylists}" Command="{Binding OpenPageCommand}" CommandParameter="Playlists"/>
             </StackPanel>
 
             <ContentPresenter x:Name="contentPresenter" Grid.Row="1" Content="{Binding Visualization.Content}"/>


### PR DESCRIPTION
Fixes #47. Now `IsChecked` property of `ToggleButtons` binded to the MainViewModel's `SelectedPage` property with `SelectedPageToToggleCheckCovnerter`. Conveter compares TypeName of the SelectedPage with name that was given to it as a parameter. If they're equal set IsChecked = true.