### PR TITLE
Switched to MDIX ColorPicker

### DIFF
--- a/src/Osu.Music.UI/Osu.Music.UI.csproj
+++ b/src/Osu.Music.UI/Osu.Music.UI.csproj
@@ -32,7 +32,6 @@
   <ItemGroup>
     <PackageReference Include="MaterialDesignThemes" Version="4.5.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.37" />
-    <PackageReference Include="PixiEditor.ColorPicker" Version="3.1.0" />
     <PackageReference Include="Prism.Wpf" Version="8.1.97" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Osu.Music.UI/ViewModels/SettingsViewModel.cs
+++ b/src/Osu.Music.UI/ViewModels/SettingsViewModel.cs
@@ -2,7 +2,7 @@
 using Osu.Music.Services.Hotkeys;
 using Osu.Music.Services.IO;
 using Osu.Music.Services.UItility;
-using Osu.Music.UI.UserControls;
+using Osu.Music.UI.Resources.Converters;
 using Prism.Commands;
 using Prism.Mvvm;
 using Prism.Services.Dialogs;
@@ -16,6 +16,17 @@ namespace Osu.Music.UI.ViewModels
     {
         public string Title => "Settings";
         public bool CanCloseDialog() => true;
+
+        private string _color;
+        public string Color
+        {
+            get => _color;
+            set
+            {
+                SetProperty(ref _color, value);
+                UpdateColor((Color)colorConverter.Convert(value, typeof(Color), null, null));
+            }
+        }
 
         private Settings _settings;
         public Settings Settings
@@ -42,15 +53,19 @@ namespace Osu.Music.UI.ViewModels
         public DelegateCommand<Color?> UpdateColorCommand { get; private set; }
         public DelegateCommand UpdateDiscordRpcCommand { get; private set; }
 
+        private ColorStringConverter colorConverter = new ColorStringConverter();
         public SettingsViewModel()
         {
+            ResourceDictionary resource = Application.Current.Resources;
+            Color = resource.MergedDictionaries.GetMainColor().ToHex();
+
             UpdateColorCommand = new DelegateCommand<Color?>(UpdateColor);
             UpdateDiscordRpcCommand = new DelegateCommand(UpdateDiscordRpc);
         }
 
         private void UpdateColor(Color? color)
         {
-            if (!color.HasValue)
+            if (!color.HasValue || Settings == null)
                 return;
 
             Settings.MainColor = color.Value.ToHex();
@@ -80,6 +95,8 @@ namespace Osu.Music.UI.ViewModels
             Settings = parameters.GetValue<Settings>("settings");
             HotkeyManager = parameters.GetValue<HotkeyManager>("hotkey");
             DiscordManager = parameters.GetValue<DiscordManager>("discord");
+
+            _color = Settings.MainColor;
         }
     }
 }

--- a/src/Osu.Music.UI/Views/DialogCreatePlaylistView.xaml
+++ b/src/Osu.Music.UI/Views/DialogCreatePlaylistView.xaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Osu.Music.UI.Views"
-             xmlns:colorpicker="clr-namespace:ColorPicker;assembly=ColorPicker"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:validators="clr-namespace:Osu.Music.UI.Resources.Validators"
              xmlns:utility="clr-namespace:Osu.Music.UI.Utility"

--- a/src/Osu.Music.UI/Views/SettingsView.xaml
+++ b/src/Osu.Music.UI/Views/SettingsView.xaml
@@ -7,7 +7,6 @@
              xmlns:prism="http://prismlibrary.com/"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:local="clr-namespace:Osu.Music.UI.Views"
-             xmlns:colorpicker="clr-namespace:ColorPicker;assembly=ColorPicker"
              xmlns:models="clr-namespace:Osu.Music.Common.Models;assembly=Osu.Music.Common"
              xmlns:uc="clr-namespace:Osu.Music.UI.UserControls"
              mc:Ignorable="d" 
@@ -28,14 +27,8 @@
             <ScrollViewer>
                 <StackPanel Orientation="Vertical" Margin="5">
                     <TextBlock Text="Player Color" Style="{DynamicResource MenuHeader}"/>
-                    <colorpicker:SquarePicker Name="ColorPicker" HorizontalAlignment="Center" Height="150" Width="150" SelectedColor="{Binding Settings.MainColor, Converter={StaticResource ColorStringConverter}}" Margin="0 0 0 50">
-                        <i:Interaction.Triggers>
-                            <i:EventTrigger EventName="ColorChanged">
-                                <prism:InvokeCommandAction Command="{Binding UpdateColorCommand}"
-                                               CommandParameter="{Binding ElementName=ColorPicker, Path=SelectedColor}" />
-                            </i:EventTrigger>
-                        </i:Interaction.Triggers>
-                    </colorpicker:SquarePicker>
+                    <materialDesign:ColorPicker Name="ColorPicker" Height="200" Color="{Binding Color, Converter={StaticResource ColorStringConverter}}" Margin="0 0 0 50">
+                    </materialDesign:ColorPicker>
 
                     <TextBlock Text="Hotkeys" Style="{DynamicResource MenuHeader}"/>
                     <ItemsControl ItemsSource="{Binding HotkeyManager.Hotkeys}" ItemTemplate="{StaticResource HotkeyTemplate}"


### PR DESCRIPTION
Fixes #44, Fixes #35 . Switched to MDIX ColorPicker. It has wierd interaction with `ColorChanged` routed event. For some reason it triggers inconsistently. To avoid it added Color property to SettingsViewModel and moved color update logic into it's setter. Not sure if it's mvvm enough. Will look into this again later. For now it works.

P.S. Also the reason behind the ScrollView glitch was previous ColorPicker, so it fixed itself in the process xd