### PR TITLE
Fixed Song Title being too wide for it to display

### DIFF
--- a/src/Osu.Music.UI/Resources/Converters/SongTitleColumnConverter.cs
+++ b/src/Osu.Music.UI/Resources/Converters/SongTitleColumnConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Osu.Music.UI.Resources.Converters
+{
+    // I'm not very fond of this solution
+    public class SongTitleColumnConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (double)value - 95.0;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Osu.Music.UI/Resources/Dictionaries/Converters.xaml
+++ b/src/Osu.Music.UI/Resources/Dictionaries/Converters.xaml
@@ -18,4 +18,5 @@
     <convert:BrushStringConverter x:Key="BrushStringConverter"/>
     <convert:PlayerObjectToStringConverter x:Key="PlayerObjectToStringConverter"/>
     <convert:SelectedPageToToggleCheckCovnerter x:Key="SelectedPageToToggleCheckCovnerter"/>
+    <convert:SongTitleColumnConverter x:Key="SongTitleColumnConverter"/>
 </ResourceDictionary>

--- a/src/Osu.Music.UI/Views/PlaylistsView.xaml
+++ b/src/Osu.Music.UI/Views/PlaylistsView.xaml
@@ -100,8 +100,8 @@
                                     </MouseBinding>
                                 </Grid.InputBindings>
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="auto"/>
+                                    <ColumnDefinition Width="{Binding ElementName=SongsList, Path=ActualWidth, Converter={StaticResource SongTitleColumnConverter}}"/>
+                                    <ColumnDefinition Width="70"/>
                                 </Grid.ColumnDefinitions>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock Style="{DynamicResource TitleStyle}" Text="{Binding Path=Title}" 
@@ -111,7 +111,8 @@
                                 </StackPanel>
 
                                 <TextBlock Style="{DynamicResource TitleStyle}" Grid.Column="1" Text="{Binding Path=TotalTime, Converter={StaticResource TimeSpanToStringConverter}, FallbackValue=''}" 
-                                   Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"/>
+                                           Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"
+                                           HorizontalAlignment="Right"/>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>

--- a/src/Osu.Music.UI/Views/SongsView.xaml
+++ b/src/Osu.Music.UI/Views/SongsView.xaml
@@ -11,7 +11,8 @@
         <ListView x:Name="SongsList" Style="{DynamicResource ListViewBeatmaps}" Grid.Column="1" Grid.Row="1" 
                   ItemsSource="{Binding DataContext.Model.Beatmaps, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainView}}}" 
                   SelectedItem="{Binding DataContext.Model.SelectedBeatmap, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainView}}}" 
-                  Tag="{Binding Path=DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainView}}}">
+                  Tag="{Binding Path=DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainView}}}"
+                  HorizontalContentAlignment="Stretch">
             <ListView.ItemTemplate>
                 <DataTemplate DataType="{x:Type m:Beatmap}">
                     <Grid>
@@ -27,8 +28,8 @@
                             </MouseBinding>
                         </Grid.InputBindings>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="auto"/>
+                            <ColumnDefinition Width="{Binding ElementName=SongsList, Path=ActualWidth, Converter={StaticResource SongTitleColumnConverter}}"/>
+                            <ColumnDefinition Width="70"/>
                         </Grid.ColumnDefinitions>
                         <StackPanel Orientation="Vertical">
                             <TextBlock Style="{DynamicResource TitleStyle}" Text="{Binding Path=Title}" 
@@ -38,7 +39,8 @@
                         </StackPanel>
 
                         <TextBlock Style="{DynamicResource TitleStyle}" Grid.Column="1" Text="{Binding Path=TotalTime, Converter={StaticResource TimeSpanToStringConverter}, FallbackValue=''}" 
-                                   Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"/>
+                                   Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"
+                                   HorizontalAlignment="Right"/>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>


### PR DESCRIPTION
`ColumnDefinition` inside songs' `ListView` is now using Binding that sets its width to `ListView.ActualWidth - 95`.

I don't really like this solution, but I didn't find anything better and all my attempts at somehow fixing it failed.