### PR TITLE
Updated styles for songs ListViewItem

### DIFF
--- a/src/Osu.Music.Common/Asynchronous/NotifyTaskCompletion.cs
+++ b/src/Osu.Music.Common/Asynchronous/NotifyTaskCompletion.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Osu.Music.Common.Asynchronous
+{
+    public sealed class NotifyTaskCompletion<TResult> : INotifyPropertyChanged
+    {
+        public NotifyTaskCompletion(Task<TResult> task)
+        {
+            Task = task;
+            if (!task.IsCompleted)
+            {
+                var _ = WatchTaskAsync(task);
+            }
+        }
+
+        private async Task WatchTaskAsync(Task task)
+        {
+            try
+            {
+                await task;
+            }
+            catch { }
+            var propertyChanged = PropertyChanged;
+
+            if (propertyChanged == null)
+                return;
+
+            propertyChanged(this, new PropertyChangedEventArgs("Status"));
+            propertyChanged(this, new PropertyChangedEventArgs("IsCompleted"));
+            propertyChanged(this, new PropertyChangedEventArgs("IsNotCompleted"));
+
+            if (task.IsCanceled)
+            {
+                propertyChanged(this, new PropertyChangedEventArgs("IsCanceled"));
+            }
+            else if (task.IsFaulted)
+            {
+                propertyChanged(this, new PropertyChangedEventArgs("IsFaulted"));
+                propertyChanged(this, new PropertyChangedEventArgs("Exception"));
+                propertyChanged(this, new PropertyChangedEventArgs("InnerException"));
+                propertyChanged(this, new PropertyChangedEventArgs("ErrorMessage"));
+            }
+            else
+            {
+                propertyChanged(this, new PropertyChangedEventArgs("IsSuccessfullyCompleted"));
+                propertyChanged(this, new PropertyChangedEventArgs("Result"));
+            }
+        }
+        public Task<TResult> Task { get; private set; }
+        public TResult Result => (Task.Status == TaskStatus.RanToCompletion) ? Task.Result : default;
+        public TaskStatus Status => Task.Status;
+        public bool IsCompleted => Task.IsCompleted;
+        public bool IsNotCompleted => !Task.IsCompleted;
+        public bool IsSuccessfullyCompleted => Task.Status == TaskStatus.RanToCompletion;
+        public bool IsCanceled => Task.IsCanceled;
+        public bool IsFaulted => Task.IsFaulted;
+        public AggregateException Exception => Task.Exception;
+        public Exception InnerException => Exception?.InnerException;
+        public string ErrorMessage => InnerException?.Message;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+}

--- a/src/Osu.Music.Common/Models/Beatmap.cs
+++ b/src/Osu.Music.Common/Models/Beatmap.cs
@@ -1,75 +1,143 @@
 ﻿using Newtonsoft.Json;
+using Prism.Mvvm;
 using System;
+using System.Drawing;
 using System.IO;
 
 namespace Osu.Music.Common.Models
 {
-    public class Beatmap
+    public class Beatmap : BindableBase
     {
+        private int _beatmapSetId;
         /// <summary>
         /// Beatmap ID.
         /// </summary>
-        public int BeatmapSetID { get; set; }
+        public int BeatmapSetId
+        {
+            get => _beatmapSetId;
+            set => SetProperty(ref _beatmapSetId, value);
+        }
 
+        private string _title;
         /// <summary>
         /// Romanised song title.
         /// </summary>
         [JsonIgnore]
-        public string Title { get; set; }
+        public string Title
+        {
+            get => _title;
+            set => SetProperty(ref _title, value);
+        }
 
+        private string _titleUnicode;
         /// <summary>
         /// Song title.
         /// </summary>
         [JsonIgnore]
-        public string TitleUnicode { get; set; }
+        public string TitleUnicode
+        {
+            get => _titleUnicode;
+            set => SetProperty(ref _titleUnicode, value);
+        }
 
+        private string _artist;
         /// <summary>
         /// Romanised song artist.
         /// </summary>
         [JsonIgnore]
-        public string Artist { get; set; }
+        public string Artist
+        {
+            get => _artist;
+            set => SetProperty(ref _artist, value);
+        }
 
+        private string _artistUnicode;
         /// <summary>
         /// Song artist.
         /// </summary>
         [JsonIgnore]
-        public string ArtistUnicode { get; set; }
+        public string ArtistUnicode
+        {
+            get => _artistUnicode;
+            set => SetProperty(ref _artistUnicode, value);
+        }
 
+        private string _creator;
         /// <summary>
         /// Beatmap creator.
         /// </summary>
         [JsonIgnore]
-        public string Creator { get; set; }
+        public string Creator
+        {
+            get => _creator;
+            set => SetProperty(ref _creator, value);
+        }
 
+        private string _audioFileName;
         /// <summary>
         /// Location of the audio file.
         /// </summary>
         [JsonIgnore]
-        public string AudioFileName { get; set; }
+        public string AudioFileName
+        {
+            get => _audioFileName;
+            set => SetProperty(ref _audioFileName, value);
+        }
 
+        private TimeSpan _totalTime;
         /// <summary>
         /// Total duration of the audio file.
         /// </summary>
         [JsonIgnore]
-        public TimeSpan TotalTime { get; set; }
+        public TimeSpan TotalTime
+        {
+            get => _totalTime;
+            set => SetProperty(ref _totalTime, value);
+        }
 
+        private string _backgroundFileName;
         /// <summary>
         /// Location of the background image file.
         /// </summary>
         [JsonIgnore]
-        public string BackgroundFileName { get; set; }
+        public string BackgroundFileName
+        {
+            get => _backgroundFileName;
+            set => SetProperty(ref _backgroundFileName, value);
+        }
 
+        private string _tags;
         /// <summary>
         /// Space-separated list of search terms.
         /// </summary>
         [JsonIgnore]
-        public string Tags { get; set; }
+        public string Tags
+        {
+            get => _tags;
+            set => SetProperty(ref _tags, value);
+        }
 
+        private string _directory;
         /// <summary>
         /// Location of the beatmap.
         /// </summary>
         [JsonIgnore]
-        public string Directory { get; set; }
+        public string Directory
+        {
+            get => _directory;
+            set => SetProperty(ref _directory, value);
+        }
+
+        private string _fileName;
+        /// <summary>
+        /// Name of the .osu file
+        /// </summary>
+        [JsonIgnore]
+        public string FileName
+        {
+            get => _fileName;
+            set => SetProperty(ref _fileName, value);
+        }
 
         /// <summary>
         /// Full path to audio file.
@@ -92,7 +160,7 @@ namespace Osu.Music.Common.Models
             else
             {
                 Beatmap b = (Beatmap)obj;
-                return BeatmapSetID == b.BeatmapSetID && Title == b.Title && Artist == b.Artist && Creator == b.Creator; // Leave only ID check?
+                return BeatmapSetId == b.BeatmapSetId && Title == b.Title && Artist == b.Artist && Creator == b.Creator; // Leave only ID check?
             }
         }
 

--- a/src/Osu.Music.Common/Models/Beatmap.cs
+++ b/src/Osu.Music.Common/Models/Beatmap.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json;
+using Osu.Music.Common.Asynchronous;
+using Osu.Music.Common.Utility;
 using Prism.Mvvm;
 using System;
 using System.Drawing;
@@ -168,5 +170,12 @@ namespace Osu.Music.Common.Models
         {
             return base.GetHashCode();
         }
+
+        //public NotifyTaskCompletion<Bitmap> Image { get; private set; }
+
+        //public Beatmap()
+        //{
+        //    Image = new NotifyTaskCompletion<Bitmap>(BackgroundRepository.GetImageAsync(this));
+        //}
     }
 }

--- a/src/Osu.Music.Common/Models/Playlist.cs
+++ b/src/Osu.Music.Common/Models/Playlist.cs
@@ -37,11 +37,11 @@ namespace Osu.Music.Common.Models
 
         public void UpdateMaps(ICollection<Beatmap> beatmaps)
         {
-            var id = Beatmaps.Select(x => x.BeatmapSetID).ToList();
-            var playlistBeatmaps = beatmaps.Where(x => id.Contains(x.BeatmapSetID)).ToList();
+            var id = Beatmaps.Select(x => x.BeatmapSetId).ToList();
+            var playlistBeatmaps = beatmaps.Where(x => id.Contains(x.BeatmapSetId)).ToList();
 
             for (int i = 0; i < Beatmaps.Count; i++)
-                Beatmaps[i] = playlistBeatmaps.Where(x => x.BeatmapSetID == Beatmaps[i].BeatmapSetID).FirstOrDefault() ?? Beatmaps[i];
+                Beatmaps[i] = playlistBeatmaps.Where(x => x.BeatmapSetId == Beatmaps[i].BeatmapSetId).FirstOrDefault() ?? Beatmaps[i];
         }
 
         #region IEditableObject Implemantation

--- a/src/Osu.Music.Common/Osu.Music.Common.csproj
+++ b/src/Osu.Music.Common/Osu.Music.Common.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HoLLy.osu.DatabaseReader" Version="3.1.0-alpha1" />
     <PackageReference Include="MaterialDesignThemes" Version="4.5.0" />
     <PackageReference Include="NAudio" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Osu.Music.Common/Utility/BackgroundRepository.cs
+++ b/src/Osu.Music.Common/Utility/BackgroundRepository.cs
@@ -1,0 +1,83 @@
+﻿using Osu.Music.Common.Models;
+using osu_database_reader.Components.Events;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Osu.Music.Common.Utility
+{
+    public class BackgroundRepository
+    {
+        public static Task<Bitmap> GetImageAsync(Beatmap beatmap)
+        {
+            return Task.Run(() =>
+            {
+                var osuFileCheck = GetFilePath(beatmap, out string osu);
+
+                if (!osuFileCheck)
+                    return new Bitmap(50, 50);
+
+                using var fs = File.OpenRead(osu);
+                var bm = BeatmapFileReader.Read(fs);
+
+                foreach (var ev in bm.Events)
+                {
+                    if (!(ev is BackgroundEvent))
+                        continue;
+
+                    var path = Path.Combine(beatmap.Directory, ((BackgroundEvent)ev).Path);
+
+                    return File.Exists(path)
+                        ? ResizeImage(new Bitmap(path), 50, 50)
+                        : new Bitmap(50, 50);
+                }
+
+                return new Bitmap(50, 50);
+            });
+        }
+
+        private static bool GetFilePath(Beatmap beatmap, out string path)
+        {
+            path = string.Empty;
+
+            if (beatmap.Directory == null || beatmap.FileName == null)
+                return false;
+
+            path = Path.Combine(beatmap.Directory, beatmap.FileName);
+            return File.Exists(path);
+        }
+
+        /// <summary>
+        /// Resize the image to the specified width and height.
+        /// </summary>
+        /// <param name="image">The image to resize.</param>
+        /// <param name="width">The width to resize to.</param>
+        /// <param name="height">The height to resize to.</param>
+        /// <returns>The resized image.</returns>
+        public static Bitmap ResizeImage(Bitmap image, int width, int height)
+        {
+            var destRect = new Rectangle(0, 0, width, height);
+
+            var destImage = new Bitmap(width, height);
+
+            destImage.SetResolution(image.HorizontalResolution,
+              image.VerticalResolution);
+
+            using (var g = Graphics.FromImage(destImage))
+            {
+                g.CompositingMode = CompositingMode.SourceCopy;
+                g.CompositingQuality = CompositingQuality.HighQuality;
+                g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                g.SmoothingMode = SmoothingMode.HighQuality;
+                g.PixelOffsetMode = PixelOffsetMode.HighQuality;
+
+                using var wrapMode = new ImageAttributes();
+                wrapMode.SetWrapMode(WrapMode.TileFlipXY);
+                g.DrawImage(image, destRect, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, wrapMode);
+            }
+            return destImage;
+        }
+    }
+}

--- a/src/Osu.Music.Common/Utility/BeatmapFileReader.cs
+++ b/src/Osu.Music.Common/Utility/BeatmapFileReader.cs
@@ -1,0 +1,62 @@
+﻿using osu_database_reader;
+using osu_database_reader.Components.Events;
+using osu_database_reader.TextFiles;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Osu.Music.Common.Utility
+{
+    public static class BeatmapFileReader
+    {
+        public static BeatmapFile Read(Stream stream)
+        {
+            var file = new BeatmapFile();
+
+            using var r = new StreamReader(stream);
+            if (!int.TryParse(r.ReadLine()?.Replace("osu file format v", string.Empty), out file.FileFormatVersion))
+                throw new Exception("Not a valid beatmap"); //very simple check, could be better
+
+            BeatmapSection? bs;
+            while ((bs = r.ReadUntilSectionStart()) != null)
+            {
+                switch (bs.Value)
+                {
+                    case BeatmapSection.Events:
+                        file.Events.AddRange(r.ReadEvents());
+                        break;
+                    default:
+                        r.ReadUntilSectionStart();
+                        break;
+                }
+            }
+
+            return file;
+        }
+
+        private static BeatmapSection? ReadUntilSectionStart(this StreamReader sr)
+        {
+            while (!sr.EndOfStream)
+            {
+                string str = sr.ReadLine();
+                if (string.IsNullOrWhiteSpace(str)) continue;
+
+                string stripped = str.TrimStart('[').TrimEnd(']');
+                if (!Enum.TryParse(stripped, out BeatmapSection a))
+                    continue;
+                return a;
+            }
+
+            //we reached an end of stream
+            return null;
+        }
+
+        private static IEnumerable<EventBase> ReadEvents(this StreamReader sr)
+        {
+            string line;
+            while (!string.IsNullOrEmpty(line = sr.ReadLine()))
+                if (!line.StartsWith("//"))
+                    yield return EventBase.FromString(line);
+        }
+    }
+}

--- a/src/Osu.Music.Services/IO/LibraryManager.cs
+++ b/src/Osu.Music.Services/IO/LibraryManager.cs
@@ -37,7 +37,7 @@ namespace Osu.Music.Services.IO
         {
             return new Beatmap()
             {
-                BeatmapSetID = entry.BeatmapSetId,
+                BeatmapSetId = entry.BeatmapSetId,
                 Title = entry.Title,
                 TitleUnicode = entry.TitleUnicode,
                 Artist = entry.Artist,

--- a/src/Osu.Music.Services/IO/LibraryManager.cs
+++ b/src/Osu.Music.Services/IO/LibraryManager.cs
@@ -46,7 +46,8 @@ namespace Osu.Music.Services.IO
                 AudioFileName = entry.AudioFileName,
                 TotalTime = TimeSpan.FromMilliseconds(entry.TotalTime),
                 Tags = entry.SongTags,
-                Directory = $@"{osuFolder}\Songs\{entry.FolderName}"
+                Directory = $@"{osuFolder}\Songs\{entry.FolderName}",
+                FileName = entry.BeatmapFileName
             };
         }
 

--- a/src/Osu.Music.Services/Osu.Music.Services.csproj
+++ b/src/Osu.Music.Services/Osu.Music.Services.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
-    <PackageReference Include="HoLLy.osu.DatabaseReader" Version="3.0.0" />
+    <PackageReference Include="HoLLy.osu.DatabaseReader" Version="3.1.0-alpha1" />
     <PackageReference Include="MaterialDesignThemes" Version="4.5.0" />
     <PackageReference Include="NAudio" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Osu.Music.UI/Resources/Converters/BeatmapToImageConverter.cs
+++ b/src/Osu.Music.UI/Resources/Converters/BeatmapToImageConverter.cs
@@ -1,0 +1,41 @@
+﻿using Osu.Music.Common.Models;
+using Osu.Music.Services.IO;
+using System;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Windows.Data;
+using System.Windows.Media.Imaging;
+
+namespace Osu.Music.UI.Resources.Converters
+{
+    public class BeatmapToImageConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var bitmap = (Bitmap)value;
+            return BitmapToImageSource(bitmap);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        private BitmapImage BitmapToImageSource(Bitmap bitmap)
+        {
+            using (MemoryStream memory = new MemoryStream())
+            {
+                bitmap.Save(memory, System.Drawing.Imaging.ImageFormat.Bmp);
+                memory.Position = 0;
+                BitmapImage bitmapimage = new BitmapImage();
+                bitmapimage.BeginInit();
+                bitmapimage.StreamSource = memory;
+                bitmapimage.CacheOption = BitmapCacheOption.OnLoad;
+                bitmapimage.EndInit();
+
+                return bitmapimage;
+            }
+        }
+    }
+}

--- a/src/Osu.Music.UI/Resources/Dictionaries/Converters.xaml
+++ b/src/Osu.Music.UI/Resources/Dictionaries/Converters.xaml
@@ -19,4 +19,5 @@
     <convert:PlayerObjectToStringConverter x:Key="PlayerObjectToStringConverter"/>
     <convert:SelectedPageToToggleCheckCovnerter x:Key="SelectedPageToToggleCheckCovnerter"/>
     <convert:SongTitleColumnConverter x:Key="SongTitleColumnConverter"/>
+    <convert:BeatmapToImageConverter x:Key="BeatmapToImageConverter"/>
 </ResourceDictionary>

--- a/src/Osu.Music.UI/Resources/Dictionaries/ListViews.xaml
+++ b/src/Osu.Music.UI/Resources/Dictionaries/ListViews.xaml
@@ -11,7 +11,7 @@
 
             <Style x:Key="ArtistStyle" TargetType="{x:Type TextBlock}">
                 <Setter Property="FontSize" Value="14"/>
-                <Setter Property="FontWeight" Value="Light"/>
+                <Setter Property="FontWeight" Value="Regular"/>
                 <Setter Property="Foreground" Value="White"/>
             </Style>
         </Style.Resources>
@@ -43,8 +43,9 @@
                                             <Condition Property="Selector.IsSelectionActive" Value="False"/>
                                             <Condition Property="IsSelected" Value="True"/>
                                         </MultiTrigger.Conditions>
-                                        <Setter Property="Background" TargetName="Bd" Value="LightGray"/>
-                                        <Setter Property="BorderBrush" TargetName="Bd" Value="LightGray"/>
+                                        <Setter Property="Background" TargetName="Bd" Value="{DynamicResource SolidColorBrushMain}"/>
+                                        <Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource SolidColorBrushMain}"/>
+                                        <Setter Property="Foreground" Value="White"/>
                                     </MultiTrigger>
                                     <MultiTrigger>
                                         <MultiTrigger.Conditions>

--- a/src/Osu.Music.UI/Resources/Dictionaries/Texts.xaml
+++ b/src/Osu.Music.UI/Resources/Dictionaries/Texts.xaml
@@ -8,7 +8,7 @@
 
     <Style x:Key="PlayerBeatmapArtist" TargetType="{x:Type TextBlock}">
         <Setter Property="FontSize" Value="14"/>
-        <Setter Property="FontWeight" Value="Light"/>
+        <Setter Property="FontWeight" Value="Regular"/>
         <Setter Property="Foreground" Value="White"/>
     </Style>
 

--- a/src/Osu.Music.UI/Views/PlaylistsView.xaml
+++ b/src/Osu.Music.UI/Views/PlaylistsView.xaml
@@ -103,16 +103,20 @@
                                     <ColumnDefinition Width="{Binding ElementName=SongsList, Path=ActualWidth, Converter={StaticResource SongTitleColumnConverter}}"/>
                                     <ColumnDefinition Width="70"/>
                                 </Grid.ColumnDefinitions>
-                                <StackPanel Orientation="Vertical">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="50"/>
+                                </Grid.RowDefinitions>
+                                <StackPanel Orientation="Vertical" VerticalAlignment="Center">
                                     <TextBlock Style="{DynamicResource TitleStyle}" Text="{Binding Path=Title}" 
                                    Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"/>
-                                    <TextBlock Style="{DynamicResource ArtistStyle}" Text="{Binding Path=Artist}"
+                                    <TextBlock Style="{DynamicResource ArtistStyle}" Text="{Binding Path=Artist}" Margin="0 5 0 0"
                                    Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"/>
                                 </StackPanel>
 
-                                <TextBlock Style="{DynamicResource TitleStyle}" Grid.Column="1" Text="{Binding Path=TotalTime, Converter={StaticResource TimeSpanToStringConverter}, FallbackValue=''}" 
-                                           Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"
-                                           HorizontalAlignment="Right"/>
+                                <TextBlock Style="{DynamicResource TitleStyle}" Grid.Column="1" 
+                                   Text="{Binding Path=TotalTime, Converter={StaticResource TimeSpanToStringConverter}, FallbackValue=''}" 
+                                   Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"
+                                   HorizontalAlignment="Right"/>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>

--- a/src/Osu.Music.UI/Views/SongsView.xaml
+++ b/src/Osu.Music.UI/Views/SongsView.xaml
@@ -31,14 +31,18 @@
                             <ColumnDefinition Width="{Binding ElementName=SongsList, Path=ActualWidth, Converter={StaticResource SongTitleColumnConverter}}"/>
                             <ColumnDefinition Width="70"/>
                         </Grid.ColumnDefinitions>
-                        <StackPanel Orientation="Vertical">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="50"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Orientation="Vertical" VerticalAlignment="Center">
                             <TextBlock Style="{DynamicResource TitleStyle}" Text="{Binding Path=Title}" 
                                    Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"/>
-                            <TextBlock Style="{DynamicResource ArtistStyle}" Text="{Binding Path=Artist}"
+                            <TextBlock Style="{DynamicResource ArtistStyle}" Text="{Binding Path=Artist}" Margin="0 5 0 0"
                                    Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"/>
                         </StackPanel>
 
-                        <TextBlock Style="{DynamicResource TitleStyle}" Grid.Column="1" Text="{Binding Path=TotalTime, Converter={StaticResource TimeSpanToStringConverter}, FallbackValue=''}" 
+                        <TextBlock Style="{DynamicResource TitleStyle}" Grid.Column="1" 
+                                   Text="{Binding Path=TotalTime, Converter={StaticResource TimeSpanToStringConverter}, FallbackValue=''}" 
                                    Foreground="{Binding RelativeSource={RelativeSource AncestorType=ContentControl}, Path=Foreground}"
                                    HorizontalAlignment="Right"/>
                     </Grid>


### PR DESCRIPTION
Closes #57 . I didn't achieve the result that I wanted. Unfortunately, loading a huge amount of images comes with its own challenges. I saved blueprints for the system, but as of now I have other priorities with this project.
Saved blueprients:
 - Osu.Music.Common.Asynchronous.NotifyTaskCompletion
 - Osu.Music.Common.Utility.BackgroundRepository
 - Osu.Music.Common.Utility.BeatmapFileReader
 - Osu.Music.Common.Models.Beatmap.Image (commented-out)

Sidenote: the system itself passed proof of concept. However, it is inconsistent (some backgrounds may load or not) and hungry for resources (up to 1.1 GB of RAM usage in addition to 50% CPU usage for the first 30 seconds after startup). 
My prediction that the reason for this is that it loads every single available image at the same time. In my case I have ~3K beatmaps. If there is a way to load only pictures for items that are currently visisble it may resolve the problem.
Why it's inconsisten still a mystery tho.